### PR TITLE
Add DRY_RUN support to deploy scripts

### DIFF
--- a/deploy/modules/01_package_lambda.sh
+++ b/deploy/modules/01_package_lambda.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
+# Allow skipping AWS calls when DRY_RUN=true
+DRY_RUN=${DRY_RUN:-false}
+
 echo "📦 Step 1: Packaging Lambda function..."
 echo "🧹 Cleaning old build directory..."
 

--- a/deploy/modules/04_setup_api_gateway.sh
+++ b/deploy/modules/04_setup_api_gateway.sh
@@ -1,16 +1,33 @@
 #!/bin/bash
 set -euo pipefail
 
+# Allow skipping AWS calls when DRY_RUN=true
+DRY_RUN=${DRY_RUN:-false}
 echo "🌐 Step 4: Setting up API Gateway: $API_NAME"
 
-REST_API_ID=$(aws apigateway get-rest-apis --query "items[?name=='$API_NAME'].id" --output text)
+if [ "${DRY_RUN:-false}" = "true" ]; then
+  echo "🧪 DRY RUN: Skipping: aws apigateway get-rest-apis --query items[?name=='$API_NAME'].id --output text"
+  REST_API_ID=""
+else
+  REST_API_ID=$(aws apigateway get-rest-apis --query "items[?name=='$API_NAME'].id" --output text)
+fi
 export REST_API_ID
 
 if [ -z "$REST_API_ID" ]; then
-  REST_API_ID=$(aws apigateway create-rest-api --name "$API_NAME" --query 'id' --output text)
+  if [ "${DRY_RUN:-false}" = "true" ]; then
+    echo "🧪 DRY RUN: Skipping: aws apigateway create-rest-api --name $API_NAME"
+  else
+    REST_API_ID=$(aws apigateway create-rest-api --name "$API_NAME" --query 'id' --output text)
+  fi
   echo "🆕 Created API Gateway: $REST_API_ID"
 else
   echo "✅ API Gateway already exists: $REST_API_ID"
 fi
 
-export PARENT_ID=$(aws apigateway get-resources --rest-api-id "$REST_API_ID" --query 'items[0].id' --output text)
+if [ "${DRY_RUN:-false}" = "true" ]; then
+  echo "🧪 DRY RUN: Skipping: aws apigateway get-resources --rest-api-id $REST_API_ID --query items[0].id --output text"
+  PARENT_ID=""
+else
+  PARENT_ID=$(aws apigateway get-resources --rest-api-id "$REST_API_ID" --query 'items[0].id' --output text)
+fi
+export PARENT_ID

--- a/deploy/modules/05_wire_proxy_route.sh
+++ b/deploy/modules/05_wire_proxy_route.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
+# Allow skipping AWS calls when DRY_RUN=true
+DRY_RUN=${DRY_RUN:-false}
+
 echo "🔗 Step 5: Wiring {proxy+} route..."
 
 # Ensure REST_API_ID is set
@@ -11,25 +14,40 @@ fi
 
 # Get or set PARENT_ID (root resource)
 if [ -z "${PARENT_ID:-}" ]; then
-  PARENT_ID=$(aws apigateway get-resources \
-    --rest-api-id "$REST_API_ID" \
-    --query 'items[0].id' \
-    --output text)
+  if [ "${DRY_RUN:-false}" = "true" ]; then
+    echo "🧪 DRY RUN: Skipping: aws apigateway get-resources --rest-api-id $REST_API_ID --query items[0].id --output text"
+    PARENT_ID=""
+  else
+    PARENT_ID=$(aws apigateway get-resources \
+      --rest-api-id "$REST_API_ID" \
+      --query 'items[0].id' \
+      --output text)
+  fi
   export PARENT_ID
 fi
 
-RESOURCE_ID=$(aws apigateway create-resource \
-  --rest-api-id "$REST_API_ID" \
-  --parent-id "$PARENT_ID" \
-  --path-part "{proxy+}" \
-  --query 'id' --output text 2>/dev/null || true)
+if [ "${DRY_RUN:-false}" = "true" ]; then
+  echo "🧪 DRY RUN: Skipping: aws apigateway create-resource --rest-api-id $REST_API_ID --parent-id $PARENT_ID --path-part {proxy+}"
+  RESOURCE_ID=""
+else
+  RESOURCE_ID=$(aws apigateway create-resource \
+    --rest-api-id "$REST_API_ID" \
+    --parent-id "$PARENT_ID" \
+    --path-part "{proxy+}" \
+    --query 'id' --output text 2>/dev/null || true)
+fi
 
 if [ -z "$RESOURCE_ID" ]; then
   echo "⚠️ {proxy+} already exists. Fetching existing resource ID..."
-  RESOURCE_ID=$(aws apigateway get-resources \
-    --rest-api-id "$REST_API_ID" \
-    --query "items[?pathPart=='{proxy+}'].id | [0]" \
-    --output text)
+  if [ "${DRY_RUN:-false}" = "true" ]; then
+    echo "🧪 DRY RUN: Skipping: aws apigateway get-resources --rest-api-id $REST_API_ID --query items[?pathPart=='{proxy+}'].id | [0] --output text"
+    RESOURCE_ID=""
+  else
+    RESOURCE_ID=$(aws apigateway get-resources \
+      --rest-api-id "$REST_API_ID" \
+      --query "items[?pathPart=='{proxy+}'].id | [0]" \
+      --output text)
+  fi
 fi
 
 if [ -z "$RESOURCE_ID" ]; then
@@ -38,25 +56,39 @@ if [ -z "$RESOURCE_ID" ]; then
 fi
 
 # Attach method and integration
-aws apigateway put-method \
-  --rest-api-id "$REST_API_ID" \
-  --resource-id "$RESOURCE_ID" \
-  --http-method ANY \
-  --authorization-type "NONE" || true
+if [ "${DRY_RUN:-false}" = "true" ]; then
+  echo "🧪 DRY RUN: Skipping: aws apigateway put-method --rest-api-id $REST_API_ID --resource-id $RESOURCE_ID"
+else
+  aws apigateway put-method \
+    --rest-api-id "$REST_API_ID" \
+    --resource-id "$RESOURCE_ID" \
+    --http-method ANY \
+    --authorization-type "NONE" || true
+fi
 
-aws apigateway put-integration \
-  --rest-api-id "$REST_API_ID" \
-  --resource-id "$RESOURCE_ID" \
-  --http-method ANY \
-  --type AWS_PROXY \
-  --integration-http-method POST \
-  --uri arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:$(aws sts get-caller-identity --query Account --output text):function:$LAMBDA_NAME/invocations || true
+if [ "${DRY_RUN:-false}" = "true" ]; then
+  echo "🧪 DRY RUN: Skipping: aws apigateway put-integration --rest-api-id $REST_API_ID --resource-id $RESOURCE_ID"
+else
+  ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+  aws apigateway put-integration \
+    --rest-api-id "$REST_API_ID" \
+    --resource-id "$RESOURCE_ID" \
+    --http-method ANY \
+    --type AWS_PROXY \
+    --integration-http-method POST \
+    --uri arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:${ACCOUNT_ID}:function:$LAMBDA_NAME/invocations || true
+fi
 
-aws lambda add-permission \
-  --function-name "$LAMBDA_NAME" \
-  --statement-id "proxy-$(date +%s)" \
-  --action lambda:InvokeFunction \
-  --principal apigateway.amazonaws.com \
-  --source-arn arn:aws:execute-api:us-east-1:$(aws sts get-caller-identity --query Account --output text):$REST_API_ID/*/*/* || true
+if [ "${DRY_RUN:-false}" = "true" ]; then
+  echo "🧪 DRY RUN: Skipping: aws lambda add-permission --function-name $LAMBDA_NAME"
+else
+  ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+  aws lambda add-permission \
+    --function-name "$LAMBDA_NAME" \
+    --statement-id "proxy-$(date +%s)" \
+    --action lambda:InvokeFunction \
+    --principal apigateway.amazonaws.com \
+    --source-arn arn:aws:execute-api:us-east-1:${ACCOUNT_ID}:$REST_API_ID/*/*/* || true
+fi
 
 echo "✅ Wired {proxy+} route successfully."

--- a/deploy/modules/06_wire_public_proxy.sh
+++ b/deploy/modules/06_wire_public_proxy.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
+# Allow skipping AWS calls when DRY_RUN=true
+DRY_RUN=${DRY_RUN:-false}
+
 echo "📁 Step 6: Wiring /public/{proxy+} route..."
 
 # Ensure REST_API_ID is set
@@ -11,67 +14,104 @@ fi
 
 # Get or set PARENT_ID (root resource)
 if [ -z "${PARENT_ID:-}" ]; then
-  PARENT_ID=$(aws apigateway get-resources \
-    --rest-api-id "$REST_API_ID" \
-    --query 'items[0].id' \
-    --output text)
+  if [ "${DRY_RUN:-false}" = "true" ]; then
+    echo "🧪 DRY RUN: Skipping: aws apigateway get-resources --rest-api-id $REST_API_ID --query items[0].id --output text"
+    PARENT_ID=""
+  else
+    PARENT_ID=$(aws apigateway get-resources \
+      --rest-api-id "$REST_API_ID" \
+      --query 'items[0].id' \
+      --output text)
+  fi
   export PARENT_ID
 fi
 
 # Get or create /public base resource
-PUBLIC_ID=$(aws apigateway get-resources \
-  --rest-api-id "$REST_API_ID" \
-  --query "items[?path=='/public'].id" \
-  --output text)
+if [ "${DRY_RUN:-false}" = "true" ]; then
+  echo "🧪 DRY RUN: Skipping: aws apigateway get-resources --rest-api-id $REST_API_ID --query items[?path=='/public'].id --output text"
+  PUBLIC_ID=""
+else
+  PUBLIC_ID=$(aws apigateway get-resources \
+    --rest-api-id "$REST_API_ID" \
+    --query "items[?path=='/public'].id" \
+    --output text)
+fi
 
 if [ -z "$PUBLIC_ID" ]; then
   echo "🆕 Creating /public base resource..."
-  PUBLIC_ID=$(aws apigateway create-resource \
-    --rest-api-id "$REST_API_ID" \
-    --parent-id "$PARENT_ID" \
-    --path-part "public" \
-    --query 'id' --output text)
+  if [ "${DRY_RUN:-false}" = "true" ]; then
+    echo "🧪 DRY RUN: Skipping: aws apigateway create-resource --rest-api-id $REST_API_ID --parent-id $PARENT_ID --path-part public"
+  else
+    PUBLIC_ID=$(aws apigateway create-resource \
+      --rest-api-id "$REST_API_ID" \
+      --parent-id "$PARENT_ID" \
+      --path-part "public" \
+      --query 'id' --output text)
+  fi
 fi
 
 # Get or create /public/{proxy+}
-PUBLIC_PROXY_ID=$(aws apigateway get-resources \
-  --rest-api-id "$REST_API_ID" \
-  --query "items[?path=='/public/{proxy+}'].id" \
-  --output text)
+if [ "${DRY_RUN:-false}" = "true" ]; then
+  echo "🧪 DRY RUN: Skipping: aws apigateway get-resources --rest-api-id $REST_API_ID --query items[?path=='/public/{proxy+}'].id --output text"
+  PUBLIC_PROXY_ID=""
+else
+  PUBLIC_PROXY_ID=$(aws apigateway get-resources \
+    --rest-api-id "$REST_API_ID" \
+    --query "items[?path=='/public/{proxy+}'].id" \
+    --output text)
+fi
 
 if [ -z "$PUBLIC_PROXY_ID" ]; then
   echo "🆕 Creating /public/{proxy+} resource..."
-  PUBLIC_PROXY_ID=$(aws apigateway create-resource \
-    --rest-api-id "$REST_API_ID" \
-    --parent-id "$PUBLIC_ID" \
-    --path-part "{proxy+}" \
-    --query 'id' --output text)
+  if [ "${DRY_RUN:-false}" = "true" ]; then
+    echo "🧪 DRY RUN: Skipping: aws apigateway create-resource --rest-api-id $REST_API_ID --parent-id $PUBLIC_ID --path-part {proxy+}"
+  else
+    PUBLIC_PROXY_ID=$(aws apigateway create-resource \
+      --rest-api-id "$REST_API_ID" \
+      --parent-id "$PUBLIC_ID" \
+      --path-part "{proxy+}" \
+      --query 'id' --output text)
+  fi
 else
   echo "✅ /public/{proxy+} already exists."
 fi
 
 # Attach ANY method
-aws apigateway put-method \
-  --rest-api-id "$REST_API_ID" \
-  --resource-id "$PUBLIC_PROXY_ID" \
-  --http-method ANY \
-  --authorization-type "NONE" || true
+if [ "${DRY_RUN:-false}" = "true" ]; then
+  echo "🧪 DRY RUN: Skipping: aws apigateway put-method --rest-api-id $REST_API_ID --resource-id $PUBLIC_PROXY_ID"
+else
+  aws apigateway put-method \
+    --rest-api-id "$REST_API_ID" \
+    --resource-id "$PUBLIC_PROXY_ID" \
+    --http-method ANY \
+    --authorization-type "NONE" || true
+fi
 
 # Set Lambda proxy integration
-aws apigateway put-integration \
-  --rest-api-id "$REST_API_ID" \
-  --resource-id "$PUBLIC_PROXY_ID" \
-  --http-method ANY \
-  --type AWS_PROXY \
-  --integration-http-method POST \
-  --uri arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:$(aws sts get-caller-identity --query Account --output text):function:$LAMBDA_NAME/invocations || true
+if [ "${DRY_RUN:-false}" = "true" ]; then
+  echo "🧪 DRY RUN: Skipping: aws apigateway put-integration --rest-api-id $REST_API_ID --resource-id $PUBLIC_PROXY_ID"
+else
+  ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+  aws apigateway put-integration \
+    --rest-api-id "$REST_API_ID" \
+    --resource-id "$PUBLIC_PROXY_ID" \
+    --http-method ANY \
+    --type AWS_PROXY \
+    --integration-http-method POST \
+    --uri arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:${ACCOUNT_ID}:function:$LAMBDA_NAME/invocations || true
+fi
 
 # Grant invoke permissions
-aws lambda add-permission \
-  --function-name "$LAMBDA_NAME" \
-  --statement-id "publicproxy-$(date +%s)" \
-  --action lambda:InvokeFunction \
-  --principal apigateway.amazonaws.com \
-  --source-arn arn:aws:execute-api:us-east-1:$(aws sts get-caller-identity --query Account --output text):$REST_API_ID/*/*/public/* || true
+if [ "${DRY_RUN:-false}" = "true" ]; then
+  echo "🧪 DRY RUN: Skipping: aws lambda add-permission --function-name $LAMBDA_NAME"
+else
+  ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+  aws lambda add-permission \
+    --function-name "$LAMBDA_NAME" \
+    --statement-id "publicproxy-$(date +%s)" \
+    --action lambda:InvokeFunction \
+    --principal apigateway.amazonaws.com \
+    --source-arn arn:aws:execute-api:us-east-1:${ACCOUNT_ID}:$REST_API_ID/*/*/public/* || true
+fi
 
 echo "✅ Wired /public/{proxy+} route successfully."

--- a/deploy/modules/07_deploy_api_gateway.sh
+++ b/deploy/modules/07_deploy_api_gateway.sh
@@ -1,10 +1,17 @@
 #!/bin/bash
 set -euo pipefail
 
+# Allow skipping AWS calls when DRY_RUN=true
+DRY_RUN=${DRY_RUN:-false}
+
 echo "🚀 Step 7: Deploying API Gateway..."
 
-aws apigateway create-deployment \
-  --rest-api-id "$REST_API_ID" \
-  --stage-name prod
+if [ "${DRY_RUN:-false}" = "true" ]; then
+  echo "🧪 DRY RUN: Skipping: aws apigateway create-deployment --rest-api-id $REST_API_ID --stage-name prod"
+else
+  aws apigateway create-deployment \
+    --rest-api-id "$REST_API_ID" \
+    --stage-name prod
+fi
 
 echo "🌎 API URL: https://${REST_API_ID}.execute-api.us-east-1.amazonaws.com/prod"

--- a/deploy/tests/test_all.sh
+++ b/deploy/tests/test_all.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
+# Ensure tests never hit AWS
+export DRY_RUN=true
+
 echo "🧪 Running all deployment modules as tests..."
 echo "---------------------------------------------"
 

--- a/deploy/tests/test_env_parity.sh
+++ b/deploy/tests/test_env_parity.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
+# Ensure tests never hit AWS
+export DRY_RUN=true
+
 echo "🔍 Testing local Docker build environment against AWS Lambda baseline..."
 echo "---------------------------------------------------------------"
 


### PR DESCRIPTION
## Summary
- add `DRY_RUN` flag to all deploy modules
- guard each AWS CLI call with a dry-run check
- ensure tests export `DRY_RUN=true`

## Testing
- `bash deploy/tests/test_all.sh --verbose` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f2dd4760483209e28f0b6a7c56dec