### PR TITLE
Fix reserved environment variable in SAM template

### DIFF
--- a/dashboard-app/backend/users.py
+++ b/dashboard-app/backend/users.py
@@ -21,7 +21,7 @@ else:
     TABLE_NAME = os.getenv("DASHBOARD_USERS_TABLE", "dashboard-users")
     dynamodb = boto3.resource(
         "dynamodb",
-        region_name=os.getenv("AWS_DEFAULT_REGION", "us-east-1")
+        region_name=os.getenv("AWS_REGION", "us-east-1")
     )
     users_table = dynamodb.Table(TABLE_NAME)
 

--- a/template.yml
+++ b/template.yml
@@ -8,7 +8,6 @@ Globals:
     Environment:
       Variables:
         DRY_RUN: "true"          # or false, as you like
-        AWS_DEFAULT_REGION: us-east-1
 
 Resources:
   DashboardFunction:


### PR DESCRIPTION
## Summary
- remove `AWS_DEFAULT_REGION` from Lambda environment
- use `AWS_REGION` in backend `users.py`

## Testing
- `bash deploy/tests/test_all.sh` *(fails: `aws` command not found)*
- `bash deploy/tests/test_all.sh --verbose` *(fails: `aws` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c047158208320897ecdaa27dc1c94