### PR TITLE
Fix deploy script path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,4 +32,4 @@ jobs:
           aws-region: us-east-1
 
       - name: 🚀 Run deploy script
-        run: bash ./deploy_backend.sh
+        run: bash ./deploy/deploy_backend.sh

--- a/dashboard_agent.py
+++ b/dashboard_agent.py
@@ -86,7 +86,7 @@ def deploy_backend():
     """Deploy backend to AWS Lambda & API Gateway"""
     click.echo("🚀 Deploying backend to Lambda & API Gateway...")
     try:
-        subprocess.run(["./deploy_backend.sh"], check=True)
+        subprocess.run(["deploy/deploy_backend.sh"], check=True)
         click.echo("✅ Backend deployed.")
     except subprocess.CalledProcessError as e:
         click.echo(f"❌ Backend deployment failed: {e}")


### PR DESCRIPTION
## Summary
- update GitHub workflow to run deploy script from `deploy/`
- fix path used by `dashboard_agent.py`

## Testing
- `bash deploy/tests/test_all.sh --quiet` *(fails: docker daemon not running)*

------
https://chatgpt.com/codex/tasks/task_e_6882ae9a28a48320b28a789970f92b01