### PR TITLE
Make SECRET_KEY configurable via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Dashboard Agent
+
+This repository contains the Dashboard Agent application and deployment scripts.
+
+## Environment Variables
+
+- `SECRET_KEY` – secret used to sign JSON Web Tokens. Set this to a random value in
+  production. The Dockerfile sets a fallback value of `change-me` so the backend
+  can run locally. Override this in your deployment or CI environment.
+

--- a/dashboard-app/backend/Dockerfile
+++ b/dashboard-app/backend/Dockerfile
@@ -2,6 +2,9 @@
 
 FROM public.ecr.aws/lambda/python:3.12
 
+# Default secret key; override in your deployment environment
+ENV SECRET_KEY=change-me
+
 # Copy the ZIP you build locally into the container
 # (make sure this path is correct relative to where you run `docker build`)
 COPY dashboard-app/dashboard-backend.zip /var/task/package.zip

--- a/dashboard-app/backend/auth.py
+++ b/dashboard-app/backend/auth.py
@@ -1,9 +1,11 @@
 from datetime import datetime, timedelta
 from jose import JWTError, jwt
 from fastapi import HTTPException, status
+import os
 
 # Secret key for JWT encoding/decoding (keep secret!)
-SECRET_KEY = "your-super-secret-key-here"  # Replace with env var in production
+# Falls back to a placeholder so the app can run locally
+SECRET_KEY = os.getenv("SECRET_KEY", "change-me")
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 60
 


### PR DESCRIPTION
## Summary
- make backend secret configurable via `os.getenv`
- set `SECRET_KEY` env in the backend Dockerfile
- document the variable in README

## Testing
- `bash deploy/tests/test_all.sh --quiet` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6882b533a1308320890439086e834ea9