### PR TITLE
Add configurable API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Dashboard Agent
+
+This repository contains the code for a small React dashboard and supporting deployment scripts.
+
+## Environment Variables
+
+`REACT_APP_API_URL`
+: Optional. Specifies the base URL for the backend API used by the React application. When defined during `npm start` or `npm run build`, this value overrides the default URL in `dashboard-app/src/api.js`.
+
+Example:
+
+```bash
+REACT_APP_API_URL=https://your-api.example.com npm start
+```
+
+If the variable is not provided, the app falls back to the production API URL hard coded in `src/api.js`.
+

--- a/dashboard-app/src/api.js
+++ b/dashboard-app/src/api.js
@@ -1,6 +1,8 @@
 // dashboard-app/src/api.js
 
-const API_BASE_URL = "https://8d2wdfciz5.execute-api.us-east-1.amazonaws.com/prod"; // <-- Update if API changes
+const API_BASE_URL =
+  process.env.REACT_APP_API_URL ||
+  "https://8d2wdfciz5.execute-api.us-east-1.amazonaws.com/prod"; // <-- Update if API changes
 
 export async function login(email, password) {
   const response = await fetch(`${API_BASE_URL}/login`, {


### PR DESCRIPTION
## Summary
- configure `API_BASE_URL` from `REACT_APP_API_URL`
- create a README documenting the new environment variable

## Testing
- `CI=true npm test -- --passWithNoTests`
- `npm run build` *(fails: Could not find a required file: index.html)*
- `bash deploy/tests/test_all.sh` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882b5320f5c83209c0d5166c8612ebc