### PR TITLE
Fix lambda build path hyphens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ dashboard-app/build/
 # dashboard-app/build/static/css/main.2ad592c5.css.map
 *.zip
 *.log
-/dashboard‑app/backend/lambda‑build
+/dashboard-app/backend/lambda-build


### PR DESCRIPTION
## Summary
- replace non-ASCII hyphens in `.gitignore` with standard ones

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6882b52e83548320b84de87569b4fc40