### PR TITLE
Add REACT_APP_API_URL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,7 @@ production:
 export SECRET_KEY="your-secret"
 ```
 
+The React frontend looks for a `REACT_APP_API_URL` variable when building.
+If set, it defines the API base URL used by `src/api.js`. When not provided,
+it falls back to the default hosted API Gateway URL.
+

--- a/dashboard-app/src/api.js
+++ b/dashboard-app/src/api.js
@@ -1,6 +1,8 @@
 // dashboard-app/src/api.js
 
-const API_BASE_URL = "https://8d2wdfciz5.execute-api.us-east-1.amazonaws.com/prod"; // <-- Update if API changes
+const API_BASE_URL =
+  process.env.REACT_APP_API_URL ||
+  "https://8d2wdfciz5.execute-api.us-east-1.amazonaws.com/prod"; // <-- Update if API changes
 
 export async function login(email, password) {
   const response = await fetch(`${API_BASE_URL}/login`, {


### PR DESCRIPTION
## Summary
- let frontend API base URL be overridden by `REACT_APP_API_URL`
- document new environment variable

## Testing
- `bash deploy/tests/test_all.sh` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882cd3b0b18832098cfc9419fb300ce