### PR TITLE
Fix packaging script

### DIFF
--- a/deploy/modules/01_package_lambda.sh
+++ b/deploy/modules/01_package_lambda.sh
@@ -40,7 +40,7 @@ mkdir -p "$(dirname "$ZIP_FILE")"
 
 # zip from inside BUILD_DIR but write to the corrected path
 pushd "$BUILD_DIR" >/dev/null
-43  zip -r "$OLDPWD/$ZIP_FILE" . >/dev/null
+zip -r "$OLDPWD/$ZIP_FILE" . >/dev/null
 popd >/dev/null
 
 echo "✅ Lambda package ready at $ZIP_FILE"


### PR DESCRIPTION
## Summary
- fix stray line number in lambda packaging script

## Testing
- `bash deploy/tests/test_all.sh` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6882d5538f208320bfe5f417ca953f97