### PR TITLE
Fix REST API ID parsing

### DIFF
--- a/deploy/modules/05_wire_proxy_route.sh
+++ b/deploy/modules/05_wire_proxy_route.sh
@@ -21,7 +21,7 @@ if [ -z "${REST_API_ID:-}" ]; then
     --stack-name dashboard-prod \
     --region us-east-1 \
     --query "Stacks[0].Outputs[?OutputKey=='ApiEndpoint'].OutputValue" \
-    --output text | awk -F'[/.]' '{print $4}')
+    --output text | awk -F'[./]' '{print $3}')
   echo "🔧 REST_API_ID auto‑detected: $REST_API_ID"
   export REST_API_ID
 fi

--- a/deploy/modules/06_wire_public_proxy.sh
+++ b/deploy/modules/06_wire_public_proxy.sh
@@ -21,7 +21,7 @@ if [ -z "${REST_API_ID:-}" ]; then
     --stack-name dashboard-prod \
     --region us-east-1 \
     --query "Stacks[0].Outputs[?OutputKey=='ApiEndpoint'].OutputValue" \
-    --output text | awk -F'[/.]' '{print $4}')
+    --output text | awk -F'[./]' '{print $3}')
   echo "🔧 REST_API_ID auto‑detected: $REST_API_ID"
   export REST_API_ID
 fi

--- a/deploy/modules/07_deploy_api_gateway.sh
+++ b/deploy/modules/07_deploy_api_gateway.sh
@@ -21,7 +21,7 @@ if [ -z "${REST_API_ID:-}" ]; then
     --stack-name dashboard-prod \
     --region us-east-1 \
     --query "Stacks[0].Outputs[?OutputKey=='ApiEndpoint'].OutputValue" \
-    --output text | awk -F'[/.]' '{print $4}')
+    --output text | awk -F'[./]' '{print $3}')
   echo "🔧 REST_API_ID auto‑detected: $REST_API_ID"
   export REST_API_ID
 fi


### PR DESCRIPTION
## Summary
- fix REST_API_ID detection in deploy scripts

## Testing
- `bash ./deploy/tests/test_all.sh` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882d7152ac88320887914b8c49697ae