### PR TITLE
Fix lambda build for Python 3.12

### DIFF
--- a/dashboard-app/backend/requirements-lambda.txt
+++ b/dashboard-app/backend/requirements-lambda.txt
@@ -1,5 +1,5 @@
 fastapi==0.111.0
-pydantic==2.6.4
+pydantic==2.11.7
 boto3
 python-jose[cryptography]
 passlib==1.7.4


### PR DESCRIPTION
## Summary
- bump pydantic in backend requirements so dependencies have prebuilt wheels for Python 3.12

## Testing
- `bash deploy/tests/test_env_parity.sh` *(fails: `docker: command not found`)*
- `bash deploy/tests/test_all.sh` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6882e4abde908320a917e1a75c185878