### PR TITLE
Fix Lambda packaging arch mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ image so it can be run locally.
 ./deploy/deploy_backend.sh --local-only
 ```
 
+When run without `--local-only` the packaging step builds Python
+dependencies inside the `public.ecr.aws/sam/build-python3.12:arm64` image so
+that compiled wheels (e.g. `pydantic-core`) match the ARM Lambda runtime. If
+you package the Lambda manually make sure to export `PACKAGE_ARCH=arm64` before
+invoking `01_package_lambda.sh`.
+
 ### Tests under `deploy/tests`
 
 The `deploy/tests` directory contains simple sanity checks.  The most commonly

--- a/deploy/deploy_backend.sh
+++ b/deploy/deploy_backend.sh
@@ -63,6 +63,7 @@ export ROLE_NAME="DashboardLambdaRole"
 export POLICY_ARN="arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess"
 export BUILD_DIR="dashboard-app/backend/lambda-build"
 export API_NAME="dashboard-api"
+export PACKAGE_ARCH="arm64"
 
 for step in \
   01_package_lambda.sh \

--- a/deploy/modules/01_package_lambda.sh
+++ b/deploy/modules/01_package_lambda.sh
@@ -6,6 +6,8 @@ BUILD_DIR=${BUILD_DIR:-dashboard-app/backend/lambda-build}
 # <-- changed default to one level up
 ZIP_FILE=${ZIP_FILE:-dashboard-app/dashboard-backend.zip}
 DRY_RUN=${DRY_RUN:-false}
+# Target architecture for dependency build (x86_64 or arm64)
+PACKAGE_ARCH=${PACKAGE_ARCH:-x86_64}
 
 : "${BUILD_DIR:?Need BUILD_DIR defined}"
 : "${ZIP_FILE:?Need ZIP_FILE defined}"
@@ -22,9 +24,14 @@ cp -r dashboard-app/backend/public          "$BUILD_DIR/"
 
 if [ "$DRY_RUN" = "false" ]; then
   echo "🐳 Installing Python dependencies…"
+  if [ "$PACKAGE_ARCH" = "arm64" ]; then
+    SAM_IMAGE="public.ecr.aws/sam/build-python3.12:arm64"
+  else
+    SAM_IMAGE="public.ecr.aws/sam/build-python3.12"
+  fi
   docker run --rm \
     -v "$PWD/$BUILD_DIR":/var/task \
-    public.ecr.aws/sam/build-python3.12 \
+    "$SAM_IMAGE" \
     /bin/bash -c "
       set -eux
       /var/lang/bin/python3.12 -m pip install --upgrade pip

--- a/deploy/tests/test_all.sh
+++ b/deploy/tests/test_all.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 # Ensure tests never hit AWS
 export DRY_RUN=true
+export PACKAGE_ARCH=arm64
 
 echo "🧪 Running all deployment modules as tests..."
 echo "---------------------------------------------"

--- a/deploy/tests/test_env_parity.sh
+++ b/deploy/tests/test_env_parity.sh
@@ -7,14 +7,14 @@ export DRY_RUN=true
 echo "🔍 Testing local Docker build environment against AWS Lambda baseline..."
 echo "---------------------------------------------------------------"
 
-EXPECTED_IMAGE="public.ecr.aws/sam/build-python3.12"
+EXPECTED_IMAGE="public.ecr.aws/sam/build-python3.12:arm64"
 EXPECTED_ARCH="aarch64"
 EXPECTED_SO_LIB="_pydantic_core"
 BUILD_DIR="dashboard-app/backend/lambda-build"
 
 # Step 1: Confirm Docker image is aarch64
 echo "🐳 Verifying Docker base image architecture..."
-IMAGE_ARCH=$(docker run --rm "$EXPECTED_IMAGE" uname -m)
+IMAGE_ARCH=$(docker run --rm --platform linux/arm64/v8 "$EXPECTED_IMAGE" uname -m)
 if [[ "$IMAGE_ARCH" == "$EXPECTED_ARCH" ]]; then
   echo "✅ Docker architecture matches Lambda ($EXPECTED_ARCH)"
 else
@@ -30,7 +30,7 @@ cp dashboard-app/backend/*.py "$BUILD_DIR/"
 cp dashboard-app/backend/requirements-lambda.txt "$BUILD_DIR/"
 cp -r dashboard-app/backend/public "$BUILD_DIR/"
 
-docker run --rm -v "$PWD/$BUILD_DIR":/var/task "$EXPECTED_IMAGE" /bin/bash -c "
+docker run --rm --platform linux/arm64/v8 -v "$PWD/$BUILD_DIR":/var/task "$EXPECTED_IMAGE" /bin/bash -c "
   set -eux
   cd /var/task
   rm -rf $EXPECTED_SO_LIB* __pycache__
@@ -63,7 +63,7 @@ fi
 
 # Step 5: Confirm Python version matches Lambda
 echo "🐍 Verifying Python version inside Docker..."
-PYTHON_VERSION=$(docker run --rm "$EXPECTED_IMAGE" /var/lang/bin/python3.12 --version)
+PYTHON_VERSION=$(docker run --rm --platform linux/arm64/v8 "$EXPECTED_IMAGE" /var/lang/bin/python3.12 --version)
 echo "🧪 Detected version: $PYTHON_VERSION"
 
 if [[ "$PYTHON_VERSION" =~ Python\ 3\.12\.[0-9]+ ]]; then


### PR DESCRIPTION
## Summary
- build Lambda deps for `arm64`
- ensure deploy script exports `PACKAGE_ARCH`
- update env parity test for arm64 runtime
- allow tests to set `PACKAGE_ARCH`
- document cross-arch packaging in README

## Testing
- `bash deploy/tests/test_all.sh --quiet` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882e8d50574832086ac29fe3cd2eb13