### PR TITLE
Add CI Docker setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,25 @@ bash deploy/tests/test_all.sh
 bash deploy/tests/test_env_parity.sh   # optional environment parity check
 ```
 
+### Docker in CI pipelines
+
+On GitHub Actions Docker is available by default on the `ubuntu-latest`
+runner. If you use a different environment or Docker is disabled, install it at
+the start of your workflow before any commands that require Docker:
+
+```yaml
+steps:
+  - name: Install Docker
+    run: |
+      sudo apt-get update
+      sudo apt-get install --yes docker.io
+      sudo systemctl start docker
+      sudo usermod -aG docker $USER
+```
+
+After installing you can confirm Docker works with `docker --version` or by
+running `docker run hello-world`.
+
 ### Local development
 
 For a quick local Lambda environment you can use the helper script under


### PR DESCRIPTION
## Summary
- document how to install Docker in CI environments

## Testing
- `bash deploy/tests/test_all.sh --quiet` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6882ed1eb7f08320a7e4a0c79faaf834