### PR TITLE
Fix arm64 packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ image so it can be run locally.
 ```
 
 When run without `--local-only` the packaging step builds Python
-dependencies inside the `public.ecr.aws/sam/build-python3.12:arm64` image so
-that compiled wheels (e.g. `pydantic-core`) match the ARM Lambda runtime. If
-you package the Lambda manually make sure to export `PACKAGE_ARCH=arm64` before
-invoking `01_package_lambda.sh`.
+dependencies inside the `public.ecr.aws/sam/build-python3.12` image using
+`--platform linux/arm64/v8` so that compiled wheels (e.g. `pydantic-core`)
+match the ARM Lambda runtime. If you package the Lambda manually make sure to
+export `PACKAGE_ARCH=arm64` before invoking `01_package_lambda.sh`.
 
 ### Tests under `deploy/tests`
 

--- a/deploy/modules/01_package_lambda.sh
+++ b/deploy/modules/01_package_lambda.sh
@@ -24,12 +24,13 @@ cp -r dashboard-app/backend/public          "$BUILD_DIR/"
 
 if [ "$DRY_RUN" = "false" ]; then
   echo "🐳 Installing Python dependencies…"
+  SAM_IMAGE="public.ecr.aws/sam/build-python3.12"
   if [ "$PACKAGE_ARCH" = "arm64" ]; then
-    SAM_IMAGE="public.ecr.aws/sam/build-python3.12:arm64"
+    DOCKER_FLAGS="--platform linux/arm64/v8"
   else
-    SAM_IMAGE="public.ecr.aws/sam/build-python3.12"
+    DOCKER_FLAGS=""
   fi
-  docker run --rm \
+  docker run --rm $DOCKER_FLAGS \
     -v "$PWD/$BUILD_DIR":/var/task \
     "$SAM_IMAGE" \
     /bin/bash -c "

--- a/deploy/tests/test_env_parity.sh
+++ b/deploy/tests/test_env_parity.sh
@@ -7,7 +7,7 @@ export DRY_RUN=true
 echo "🔍 Testing local Docker build environment against AWS Lambda baseline..."
 echo "---------------------------------------------------------------"
 
-EXPECTED_IMAGE="public.ecr.aws/sam/build-python3.12:arm64"
+EXPECTED_IMAGE="public.ecr.aws/sam/build-python3.12"
 EXPECTED_ARCH="aarch64"
 EXPECTED_SO_LIB="_pydantic_core"
 BUILD_DIR="dashboard-app/backend/lambda-build"


### PR DESCRIPTION
## Summary
- avoid nonexistent arm64 image tag when packaging
- document using `--platform` flag for lambda builds

## Testing
- `bash deploy/tests/test_all.sh` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6882ee4964408320937627aa84f76f27