### PR TITLE
Fix Docker install step for Ubuntu 24.04

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Install Docker
         run: |
           sudo apt-get update
+          sudo apt-get remove --yes containerd || true
           sudo apt-get install --yes docker.io
           sudo systemctl start docker
           sudo usermod -aG docker $USER

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ steps:
   - name: Install Docker
     run: |
       sudo apt-get update
+      sudo apt-get remove --yes containerd || true
       sudo apt-get install --yes docker.io
       sudo systemctl start docker
       sudo usermod -aG docker $USER


### PR DESCRIPTION
## Summary
- remove conflicting containerd package before installing docker.io
- update README with the same instructions

## Testing
- `bash deploy/tests/test_all.sh` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6882f249892c8320b87e3771c3e88b6c