### PR TITLE
Fix docker step in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,13 +23,9 @@ jobs:
           python3 -m pip install --upgrade pip
           pip install awscli
 
-      - name: Install Docker
+      - name: Ensure Docker is running
         run: |
-          sudo apt-get update
-          sudo apt-get remove --yes containerd || true
-          sudo apt-get install --yes docker.io
-          sudo systemctl start docker
-          sudo usermod -aG docker $USER
+          sudo systemctl start docker || true
 
 
       - name: 🔐 Configure AWS credentials


### PR DESCRIPTION
## Summary
- remove outdated docker package installation in CI
- just ensure the Docker service is running

## Testing
- `bash deploy/tests/test_all.sh --quiet` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6882f3e4d8f483208b54c6befd090308