### PR TITLE
docs: clarify arm64 packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,12 @@ image so it can be run locally.
 ./deploy/deploy_backend.sh --local-only
 ```
 
-When run without `--local-only` the packaging step builds Python
-dependencies inside the `public.ecr.aws/sam/build-python3.12` image using
-`--platform linux/arm64/v8` so that compiled wheels (e.g. `pydantic-core`)
-match the ARM Lambda runtime. If you package the Lambda manually make sure to
-export `PACKAGE_ARCH=arm64` before invoking `01_package_lambda.sh`.
+When run without `--local-only` the packaging step uses Docker to build Python
+dependencies inside the `public.ecr.aws/sam/build-python3.12` image. The
+`--platform linux/arm64/v8` flag ensures packages like `pydantic-core` compile
+correctly for the ARM Lambda runtime. This works out of the box on GitHub
+runners because Docker is preinstalled. If you package the Lambda manually make
+sure to export `PACKAGE_ARCH=arm64` before invoking `01_package_lambda.sh`.
 
 ### Tests under `deploy/tests`
 


### PR DESCRIPTION
## Summary
- clarify how `--platform linux/arm64/v8` ensures packages compile for Lambda
- mention that Docker is preinstalled on GitHub runners

## Testing
- `bash deploy/tests/test_all.sh` *(fails: Cannot connect to the Docker daemon)*
- `bash deploy/tests/test_env_parity.sh` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6882f6512c188320a5049ff3000e54b4