### PR TITLE
Fix invalid path entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,4 @@ dashboard-app/build/
 *.zip
 *.log
 /dashboard-app/backend/lambda-build
-/dashboard‑app/backend/lambda‑build
 packaged.yml


### PR DESCRIPTION
## Summary
- remove malformed /dashboard‑app/backend/lambda‑build line from `.gitignore`

## Testing
- `bash deploy/tests/test_all.sh` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6882f64454c08320a5dbfdd5b66f5d4c