### PR TITLE
Fix pipeline by enabling QEMU

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,11 @@ jobs:
         run: |
           sudo systemctl start docker || true
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: arm64
+
 
       - name: 🔐 Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow to install QEMU so the ARM64 Docker image can run

## Testing
- `bash deploy/tests/test_all.sh` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6882f5890ec8832082c8ec2bf7173217