### PR TITLE
Fix default packaging architecture for Lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ When run without `--local-only` the packaging step uses Docker to build Python
 dependencies inside the `public.ecr.aws/sam/build-python3.12` image. The
 `--platform linux/arm64/v8` flag ensures packages like `pydantic-core` compile
 correctly for the ARM Lambda runtime. This works out of the box on GitHub
-runners because Docker is preinstalled. If you package the Lambda manually make
-sure to export `PACKAGE_ARCH=arm64` before invoking `01_package_lambda.sh`.
+runners because Docker is preinstalled. The packaging script now defaults to
+`arm64`; override `PACKAGE_ARCH` if you need a different architecture.
 
 ### Tests under `deploy/tests`
 
@@ -121,13 +121,12 @@ the Lambda package was likely built for the wrong CPU architecture. The provided
 deployment scripts create an **arm64** Lambda, so all dependencies must also be
 compiled for `arm64`.
 
-When packaging manually run the build inside the SAM Docker image with
-`PACKAGE_ARCH=arm64`:
+When packaging manually run the build inside the SAM Docker image:
 
 ```bash
-export PACKAGE_ARCH=arm64
 bash deploy/modules/01_package_lambda.sh
 ```
+You can override the architecture by setting `PACKAGE_ARCH` if necessary.
 
 Alternatively you can install dependencies directly specifying the platform:
 

--- a/deploy/modules/01_package_lambda.sh
+++ b/deploy/modules/01_package_lambda.sh
@@ -7,7 +7,8 @@ BUILD_DIR=${BUILD_DIR:-dashboard-app/backend/lambda-build}
 ZIP_FILE=${ZIP_FILE:-dashboard-app/dashboard-backend.zip}
 DRY_RUN=${DRY_RUN:-false}
 # Target architecture for dependency build (x86_64 or arm64)
-PACKAGE_ARCH=${PACKAGE_ARCH:-x86_64}
+# Default to arm64 to match the Lambda architecture
+PACKAGE_ARCH=${PACKAGE_ARCH:-arm64}
 
 : "${BUILD_DIR:?Need BUILD_DIR defined}"
 : "${ZIP_FILE:?Need ZIP_FILE defined}"


### PR DESCRIPTION
## Summary
- default `PACKAGE_ARCH` to arm64 in the Lambda packaging script
- update README to reflect the default architecture and clarify how to override it

## Testing
- `bash deploy/tests/test_all.sh` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68830ebb434c83209451818de3aa34e1