### PR TITLE
Fix AWS CLI version in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,10 +18,11 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install AWS CLI via pip
+      - name: Install AWS CLI v2
         run: |
-          python3 -m pip install --upgrade pip
-          pip install awscli
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o awscliv2.zip
+          unzip -q awscliv2.zip
+          sudo ./aws/install --update
 
       - name: Ensure Docker is running
         run: |


### PR DESCRIPTION
## Summary
- install AWS CLI v2 in GitHub Actions workflow

## Testing
- `bash deploy/tests/test_all.sh` *(fails: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688372ccb2a48320817a27c9af6d2b4b