### PR TITLE
Improve docs for AWS CLI v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,24 @@ steps:
       sudo usermod -aG docker $USER
 ```
 
+
 After installing you can confirm Docker works with `docker --version` or by
 running `docker run hello-world`.
+
+### AWS CLI v2
+
+Several deployment scripts rely on features only available in AWS CLI **v2**.
+On Debian/Ubuntu based systems you can install it with:
+
+```bash
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o awscliv2.zip
+unzip -q awscliv2.zip
+sudo ./aws/install --update
+aws --version  # should report aws-cli/2.x
+```
+
+Make sure `aws --version` prints a 2.x release before running the tests or
+`deploy/deploy_backend.sh`.
 
 ### Local development
 

--- a/deploy/tests/test_all.sh
+++ b/deploy/tests/test_all.sh
@@ -35,10 +35,18 @@ for arg in "$@"; do
   esac
 done
 
-# Detect aws CLI and warn if missing
+# Detect aws CLI and verify v2
 if ! command -v aws >/dev/null 2>&1; then
   echo "⚠️  'aws' command not found. AWS-related modules will be skipped."
   AWS_AVAILABLE=false
+else
+  AWS_VER_OUTPUT=$(aws --version 2>&1)
+  if [[ $AWS_VER_OUTPUT =~ aws-cli\/2 ]]; then
+    AWS_AVAILABLE=true
+  else
+    echo "⚠️  AWS CLI v2 required. Found: $AWS_VER_OUTPUT"
+    AWS_AVAILABLE=false
+  fi
 fi
 
 # Shared config


### PR DESCRIPTION
## Summary
- mention AWS CLI v2 requirement and installation steps
- verify AWS CLI v2 in deployment tests

## Testing
- `bash deploy/tests/test_all.sh` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688374e1482483208328ccabc7c01b8a